### PR TITLE
Build a simple, config-driven domain crawler + file downloader (Step-1 discover, Step-2 download)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Instructions
+
+- Run `bash scripts/smoke_run.sh` after making changes.
+- Keep code simple and dependency-light. Standard PEP8 style is preferred.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Webscrapper_basic
-testing
+
+Simple config-driven domain crawler and file downloader.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+cp config.example.yml config.yml
+python -m crawler discover --config config.yml
+python -m crawler download --config config.yml
+```
+
+`discover` crawls pages within the configured domain, records downloadable files to `state/manifest.jsonl`, and prints a summary.
+`download` retrieves any files listed in the manifest, storing them under `out/` while skipping unchanged files on re-runs.
+
+## Incremental behaviour
+
+The crawler keeps state in the `state/` directory:
+
+- `visited_urls.txt`: pages already visited
+- `manifest.jsonl`: metadata for each discovered or downloaded file
+
+When `download` runs, it checks ETag/Last-Modified headers (or file hashes) to skip files that have not changed.
+
+## Smoke test
+
+Run the included script for a tiny end-to-end test against a public site:
+
+```bash
+bash scripts/smoke_run.sh
+```

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,15 @@
+start_url: https://www.w3.org/WAI/ER/tests/xhtml/testfiles/
+allowed_domain: www.w3.org
+output_dir: ./out
+state_dir: ./state
+max_pages: 20
+max_depth: 2
+respect_robots_txt: true
+allowed_extensions:
+  - ".pdf"
+follow_subdomains: false
+rate_limit_sec: 0.5
+timeout_sec: 20
+user_agent: Webscrapper-basic
+retries: 2
+ignore_query_params: true

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -1,0 +1,3 @@
+"""Config-driven web crawler and downloader package."""
+
+__all__ = []

--- a/crawler/__main__.py
+++ b/crawler/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/crawler/cli.py
+++ b/crawler/cli.py
@@ -1,0 +1,31 @@
+"""Command line interface for the crawler."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .config import load_config
+from .crawl import discover
+from .download import download as download_files
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="crawler")
+    parser.add_argument("mode", choices=["discover", "download"], help="Operation mode")
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
+    args = parser.parse_args(argv)
+
+    cfg = load_config(Path(args.config))
+    if args.mode == "discover":
+        pages, ext_counts = discover(cfg)
+        total_files = sum(ext_counts.values())
+        print(f"Visited {pages} pages; discovered {total_files} files: {dict(ext_counts)}")
+    else:
+        downloaded, skipped, failed = download_files(cfg)
+        print(
+            f"Downloaded {downloaded} files; skipped {skipped} unchanged; {failed} failures"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -1,0 +1,47 @@
+"""Configuration loading utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+import yaml
+
+
+def _default_exts() -> List[str]:
+    return [".pdf", ".doc", ".docx", ".xls", ".xlsx", ".csv", ".zip"]
+
+
+@dataclass
+class Config:
+    """Dataclass representing crawler configuration."""
+
+    start_url: str
+    allowed_domain: str
+    output_dir: Path = Path("./out")
+    state_dir: Path = Path("./state")
+    max_pages: int = 10_000
+    max_depth: int = 10
+    respect_robots_txt: bool = True
+    allowed_extensions: List[str] = field(default_factory=_default_exts)
+    follow_subdomains: bool = False
+    rate_limit_sec: float = 0.5
+    timeout_sec: int = 20
+    user_agent: str = "SimpleCrawler/0.1 (+https://example.com)"
+    retries: int = 2
+    ignore_query_params: bool = True
+
+
+def load_config(path: Path) -> Config:
+    """Load configuration from YAML file.
+
+    Parameters
+    ----------
+    path: Path
+        Path to YAML configuration file.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    cfg = Config(**data)
+    cfg.output_dir = Path(cfg.output_dir)
+    cfg.state_dir = Path(cfg.state_dir)
+    return cfg

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -1,0 +1,103 @@
+"""Crawling logic for discovery mode."""
+from __future__ import annotations
+
+from collections import deque, defaultdict
+from datetime import datetime
+import logging
+import time
+from pathlib import Path
+from typing import Dict, Set, Deque, Tuple
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+
+from .config import Config
+from .state import CrawlState
+from .parse import extract_links
+from .utils import normalize_url, is_within_domain, request_with_retries
+
+
+logger = logging.getLogger(__name__)
+
+
+def discover(cfg: Config) -> Tuple[int, Dict[str, int]]:
+    """Perform crawl and log discovered files.
+
+    Returns
+    -------
+    tuple
+        pages_visited, dict of extension -> count
+    """
+    logs_dir = Path("logs")
+    logs_dir.mkdir(exist_ok=True)
+    handler = logging.FileHandler(logs_dir / "crawl.log")
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+    state = CrawlState(cfg.state_dir)
+    session = requests.Session()
+    session.headers["User-Agent"] = cfg.user_agent
+
+    rp: RobotFileParser | None = None
+    if cfg.respect_robots_txt:
+        rp = RobotFileParser()
+        robots_url = f"https://{cfg.allowed_domain}/robots.txt"
+        try:
+            rp.set_url(robots_url)
+            rp.read()
+        except Exception:
+            rp = None
+
+    queue: Deque[Tuple[str, int]] = deque([(cfg.start_url, 0)])
+    pages_visited = 0
+    ext_counts: Dict[str, int] = defaultdict(int)
+
+    while queue and pages_visited < cfg.max_pages:
+        url, depth = queue.popleft()
+        norm = normalize_url(url, cfg.ignore_query_params)
+        if norm in state.visited or depth > cfg.max_depth:
+            continue
+        if not is_within_domain(norm, cfg.allowed_domain, cfg.follow_subdomains):
+            continue
+        if rp and not rp.can_fetch(cfg.user_agent, norm):
+            logger.info("Blocked by robots: %s", norm)
+            continue
+        try:
+            resp = request_with_retries(session, "GET", norm, cfg.retries, cfg.timeout_sec)
+        except Exception as exc:
+            logger.warning("Failed to fetch %s: %s", norm, exc)
+            state.visited.add(norm)
+            continue
+        state.visited.add(norm)
+        pages_visited += 1
+        ctype = resp.headers.get("Content-Type", "")
+        if "text/html" not in ctype:
+            continue
+        links = extract_links(resp.text, norm)
+        for link in links:
+            link_norm = normalize_url(link, cfg.ignore_query_params)
+            if any(link_norm.lower().endswith(ext) for ext in cfg.allowed_extensions):
+                ext = Path(link_norm).suffix.lower()
+                ext_counts[ext] += 1
+                entry = state.manifest.get(link_norm, {})
+                entry.update(
+                    {
+                        "discovered_at": datetime.utcnow().isoformat(),
+                        "source_page": norm,
+                        "file_url": link_norm,
+                        "file_path": None,
+                        "status": "discovered",
+                        "http_status": None,
+                        "etag": None,
+                        "last_modified": None,
+                        "sha256": None,
+                        "size_bytes": None,
+                    }
+                )
+                state.manifest[link_norm] = entry
+            else:
+                if link_norm not in state.visited:
+                    queue.append((link_norm, depth + 1))
+        time.sleep(cfg.rate_limit_sec)
+    state.save()
+    return pages_visited, ext_counts

--- a/crawler/download.py
+++ b/crawler/download.py
@@ -1,0 +1,82 @@
+"""Download logic for files discovered by the crawler."""
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+import hashlib
+from pathlib import Path
+from typing import Tuple
+
+import requests
+
+from .config import Config
+from .state import CrawlState
+from .utils import (
+    file_url_to_path,
+    request_with_retries,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def download(cfg: Config) -> Tuple[int, int, int]:
+    """Download files listed in the manifest.
+
+    Returns
+    -------
+    tuple
+        downloaded, skipped, failed counts
+    """
+    state = CrawlState(cfg.state_dir)
+    session = requests.Session()
+    session.headers["User-Agent"] = cfg.user_agent
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded = skipped = failed = 0
+    for url, entry in list(state.manifest.items()):
+        try:
+            head = request_with_retries(session, "HEAD", url, cfg.retries, cfg.timeout_sec, allow_redirects=True)
+            etag = head.headers.get("ETag")
+            last_mod = head.headers.get("Last-Modified")
+            if (etag and entry.get("etag") == etag) or (
+                last_mod and entry.get("last_modified") == last_mod
+            ):
+                entry.update({
+                    "status": "skipped_unchanged",
+                    "http_status": head.status_code,
+                    "etag": etag,
+                    "last_modified": last_mod,
+                })
+                skipped += 1
+                continue
+            resp = request_with_retries(session, "GET", url, cfg.retries, cfg.timeout_sec, stream=True)
+            resp.raise_for_status()
+            rel = file_url_to_path(url)
+            dest = cfg.output_dir / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            h = hashlib.sha256()
+            size = 0
+            with open(dest, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    f.write(chunk)
+                    h.update(chunk)
+                    size += len(chunk)
+            entry.update({
+                "file_path": str(dest),
+                "status": "downloaded",
+                "http_status": resp.status_code,
+                "etag": etag,
+                "last_modified": last_mod,
+                "sha256": h.hexdigest(),
+                "size_bytes": size,
+            })
+            downloaded += 1
+        except Exception as exc:
+            logger.warning("Failed to download %s: %s", url, exc)
+            entry.update({"status": "failed"})
+            failed += 1
+        state.manifest[url] = entry
+    state.save()
+    return downloaded, skipped, failed

--- a/crawler/parse.py
+++ b/crawler/parse.py
@@ -1,0 +1,15 @@
+"""HTML parsing helpers."""
+from __future__ import annotations
+
+from typing import Iterable, List
+from urllib.parse import urljoin
+from bs4 import BeautifulSoup
+
+
+def extract_links(html: str, base_url: str) -> List[str]:
+    """Extract absolute links from HTML text."""
+    soup = BeautifulSoup(html, "html.parser")
+    links: List[str] = []
+    for a in soup.find_all("a", href=True):
+        links.append(urljoin(base_url, a["href"]))
+    return links

--- a/crawler/state.py
+++ b/crawler/state.py
@@ -1,0 +1,42 @@
+"""State persistence utilities."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Set, Any
+
+
+@dataclass
+class CrawlState:
+    """Represents crawling state loaded from disk."""
+
+    state_dir: Path
+    visited: Set[str] = field(default_factory=set)
+    manifest: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.visited_file = self.state_dir / "visited_urls.txt"
+        self.manifest_file = self.state_dir / "manifest.jsonl"
+        self._load()
+
+    def _load(self) -> None:
+        if self.visited_file.exists():
+            self.visited = set(
+                url.strip() for url in self.visited_file.read_text().splitlines() if url.strip()
+            )
+        if self.manifest_file.exists():
+            with self.manifest_file.open("r", encoding="utf-8") as f:
+                for line in f:
+                    data = json.loads(line)
+                    self.manifest[data["file_url"]] = data
+
+    def save(self) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        with self.visited_file.open("w", encoding="utf-8") as f:
+            for url in sorted(self.visited):
+                f.write(url + "\n")
+        with self.manifest_file.open("w", encoding="utf-8") as f:
+            for entry in self.manifest.values():
+                json.dump(entry, f)
+                f.write("\n")

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -1,0 +1,49 @@
+"""Miscellaneous utility helpers."""
+from __future__ import annotations
+
+import time
+import hashlib
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse, urljoin
+import requests
+
+
+def normalize_url(url: str, ignore_query: bool = True) -> str:
+    """Normalize URL by stripping fragment and optionally query parameters."""
+    parsed = urlparse(url)
+    query = "" if ignore_query else parsed.query
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path or "/", "", query, ""))
+
+
+def is_within_domain(url: str, allowed_domain: str, follow_subdomains: bool) -> bool:
+    host = urlparse(url).hostname or ""
+    if follow_subdomains:
+        return host.endswith(allowed_domain)
+    return host == allowed_domain
+
+
+def file_url_to_path(url: str) -> Path:
+    """Convert a file URL to a relative local path."""
+    parsed = urlparse(url)
+    return Path(parsed.path.lstrip("/"))
+
+
+def request_with_retries(session: requests.Session, method: str, url: str, retries: int, timeout: int, **kwargs) -> requests.Response:
+    """Perform HTTP request with simple retry logic."""
+    for attempt in range(retries + 1):
+        try:
+            resp = session.request(method, url, timeout=timeout, **kwargs)
+            return resp
+        except requests.RequestException:
+            if attempt == retries:
+                raise
+            time.sleep(0.5)
+
+
+def sha256_file(path: Path) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+PyYAML
+tqdm

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+python -m crawler discover --config config.example.yml
+python -m crawler download --config config.example.yml


### PR DESCRIPTION
## Summary
- scaffold crawler package with config loader, CLI, discovery and download logic
- provide example YAML config, requirements, and smoke test script
- document quickstart and incremental behavior in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*
- `bash scripts/smoke_run.sh` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68ba59abd568832c8d15728e0c8bda54