### PR TITLE
Include domain in download paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ python -m crawler download --config config.yml
 ```
 
 `discover` crawls pages within the configured domain, records downloadable files to `state/manifest.jsonl`, and prints a summary.
-`download` retrieves any files listed in the manifest, storing them under `out/` while skipping unchanged files on re-runs.
+`download` retrieves any files listed in the manifest and saves them under `out/`,
+replicating the site's domain and path. Unchanged files are skipped on re-runs.
 
 ## Incremental behaviour
 

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -25,7 +25,7 @@ def is_within_domain(url: str, allowed_domain: str, follow_subdomains: bool) -> 
 def file_url_to_path(url: str) -> Path:
     """Convert a file URL to a relative local path."""
     parsed = urlparse(url)
-    return Path(parsed.path.lstrip("/"))
+    return Path(parsed.netloc) / parsed.path.lstrip("/")
 
 
 def request_with_retries(session: requests.Session, method: str, url: str, retries: int, timeout: int, **kwargs) -> requests.Response:


### PR DESCRIPTION
## Summary
- Ensure downloaded files mimic source site structure by prefixing the URL's domain when mapping file URLs to local paths.
- Document that downloads now reproduce the site's domain and path.

## Testing
- `bash scripts/smoke_run.sh` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5db07f04832c9c7afc1a82abac1f