### PR TITLE
Expose progress bars and add verbose flag

### DIFF
--- a/crawler/cli.py
+++ b/crawler/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 from .config import load_config
@@ -13,7 +14,14 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="crawler")
     parser.add_argument("mode", choices=["discover", "download"], help="Operation mode")
     parser.add_argument("--config", required=True, help="Path to YAML config file")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging to the console",
+    )
     args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING)
 
     cfg = load_config(Path(args.config))
     if args.mode == "discover":

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -31,9 +31,9 @@ def discover(cfg: Config) -> Tuple[int, Dict[str, int]]:
     """
     logs_dir = Path("logs")
     logs_dir.mkdir(exist_ok=True)
-    handler = logging.FileHandler(logs_dir / "crawl.log")
-    console = logging.StreamHandler()
-    logging.basicConfig(level=logging.INFO, handlers=[handler, console])
+    if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+        logger.addHandler(logging.FileHandler(logs_dir / "crawl.log"))
+    logger.setLevel(logging.INFO)
 
     state = CrawlState(cfg.state_dir)
     session = requests.Session()

--- a/crawler/download.py
+++ b/crawler/download.py
@@ -16,10 +16,6 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    handler = logging.StreamHandler()
-    logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 
 def download(cfg: Config) -> Tuple[int, int, int]:


### PR DESCRIPTION
## Summary
- ensure progress bars are shown for discover and download by removing logging redirection
- add --verbose flag to CLI to enable INFO level logging

## Testing
- `bash scripts/smoke_run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ba631de0d8832ca133a84387a873c4